### PR TITLE
Add license to setup info.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,5 @@
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup(use_scm_version=True)
+    setuptools.setup(use_scm_version=True
+                    license='MIT')


### PR DESCRIPTION
This exposes it to automated scanning with tools like pip-licenses.