### PR TITLE
Allow `.name` on root Path object

### DIFF
--- a/test_zipp.py
+++ b/test_zipp.py
@@ -181,3 +181,11 @@ class TestEverything(unittest.TestCase):
         for zipfile_abcde in self.zipfile_abcde():
             root = zipp.Path(zipfile_abcde)
             assert (root / 'missing dir/').parent.at == ''
+
+    def test_root_name(self):
+        """
+        The name of the root should be the name of the zipfile
+        """
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipp.Path(zipfile_abcde)
+            assert root.name == 'abcde.zip'

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -189,3 +189,17 @@ class TestEverything(unittest.TestCase):
         for zipfile_abcde in self.zipfile_abcde():
             root = zipp.Path(zipfile_abcde)
             assert root.name == 'abcde.zip'
+
+    def test_root_name_unnamed(self):
+        """
+        It is an error to attempt to get the name of an unnamed zipfile.
+        """
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipp.Path(zipfile_abcde)
+            root.root.filename = None
+            try:
+                root.name
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("did not raise")

--- a/zipp.py
+++ b/zipp.py
@@ -3,6 +3,7 @@
 from __future__ import division
 
 import io
+import os
 import sys
 import posixpath
 import zipfile
@@ -103,7 +104,14 @@ class Path:
 
     @property
     def name(self):
-        return posixpath.basename(self.at.rstrip("/"))
+        return posixpath.basename(self.at.rstrip("/")) \
+            or os.path.basename(self._root_filename())
+
+    def _root_filename(self):
+        value = self.root.filename
+        if value is None:
+            raise ValueError("Zip file has no filename")
+        return value
 
     def read_text(self, *args, **kwargs):
         with self.open() as strm:


### PR DESCRIPTION
Fixes #9

I'm hesitant to adopt this change because it has non-obvious boundary conditions depending on the underlying zip file. In particular, if the underlying zip file has no filename, this code elects to raise a `ValueError`, illustrated in 5c653bc903b0f32cea6a5121e83c4a449e36dd3a.

I'm also hesitant because it feels like `.name` shouldn't be special - that perhaps a root-level `Path` should defer to `pathlib.Path(self.root.filename)` for operations not relevant to the zipfile, such as `.name`, `.parent`, and maybe others (`.stem`, `.parents`, `.root` are all plausible).