### PR TITLE
Allow .name and .parent on unnamed root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v3.3.0
+======
+
+#9: ``Path`` objects now expose a ``.filename`` attribute
+and rely on that to resolve ``.name`` and ``.parent`` when
+the ``Path`` object is at the root of the zipfile.
+
 v3.2.0
 ======
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7
 install_requires =
+	pathlib2; python_version < "3.4"
 setup_requires = setuptools_scm >= 1.15.0
 
 [options.extras_require]
@@ -29,7 +30,6 @@ testing =
 	# upstream
 
 	# local
-	pathlib2
 	contextlib2
 	unittest2
 

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -222,3 +222,8 @@ class TestEverything(unittest.TestCase):
                 pass
             else:
                 raise AssertionError("did not raise")
+
+            # .name and .parent should still work on subs
+            sub = root / "b"
+            assert sub.name == "b"
+            assert sub.parent

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -181,3 +181,11 @@ class TestEverything(unittest.TestCase):
         for zipfile_abcde in self.zipfile_abcde():
             root = zipp.Path(zipfile_abcde)
             assert (root / 'missing dir/').parent.at == ''
+
+    def test_root_name(self):
+        """
+        The name of the root should be the name of the zipfile
+        """
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipp.Path(zipfile_abcde)
+            assert root.name == 'abcde.zip'

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -189,3 +189,17 @@ class TestEverything(unittest.TestCase):
         for zipfile_abcde in self.zipfile_abcde():
             root = zipp.Path(zipfile_abcde)
             assert root.name == 'abcde.zip'
+
+    def test_root_name_unnamed(self):
+        """
+        It is an error to attempt to get the name of an unnamed zipfile.
+        """
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipp.Path(zipfile_abcde)
+            root.root.filename = None
+            try:
+                root.name
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("did not raise")

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -182,24 +182,43 @@ class TestEverything(unittest.TestCase):
             root = zipp.Path(zipfile_abcde)
             assert (root / 'missing dir/').parent.at == ''
 
+    def test_filename(self):
+        for zipfile_abcde in self.zipfile_abcde():
+            root = zipp.Path(zipfile_abcde)
+            assert root.filename == pathlib.Path('abcde.zip')
+
     def test_root_name(self):
         """
         The name of the root should be the name of the zipfile
         """
         for zipfile_abcde in self.zipfile_abcde():
             root = zipp.Path(zipfile_abcde)
-            assert root.name == 'abcde.zip'
+            assert root.name == 'abcde.zip' == root.filename.name
 
-    def test_root_name_unnamed(self):
-        """
-        It is an error to attempt to get the name of an unnamed zipfile.
-        """
+    def test_root_parent(self):
         for zipfile_abcde in self.zipfile_abcde():
             root = zipp.Path(zipfile_abcde)
-            root.root.filename = None
+            assert root.parent == pathlib.Path('.')
+            root.root.filename = 'foo/bar.zip'
+            assert root.parent == pathlib.Path('foo')
+
+    def test_root_unnamed(self):
+        """
+        It is an error to attempt to get the name
+        or parent of an unnamed zipfile.
+        """
+        for zipfile_abcde in self.zipfile_abcde():
+            zipfile_abcde.filename = None
+            root = zipp.Path(zipfile_abcde)
             try:
                 root.name
-            except ValueError:
+            except TypeError:
+                pass
+            else:
+                raise AssertionError("did not raise")
+            try:
+                root.parent
+            except TypeError:
                 pass
             else:
                 raise AssertionError("did not raise")

--- a/zipp.py
+++ b/zipp.py
@@ -3,6 +3,7 @@
 from __future__ import division
 
 import io
+import os
 import sys
 import posixpath
 import zipfile
@@ -103,7 +104,14 @@ class Path:
 
     @property
     def name(self):
-        return posixpath.basename(self.at.rstrip("/"))
+        return posixpath.basename(self.at.rstrip("/")) \
+            or os.path.basename(self._root_filename())
+
+    def _root_filename(self):
+        value = self.root.filename
+        if value is None:
+            raise ValueError("Zip file has no filename")
+        return value
 
     def read_text(self, *args, **kwargs):
         with self.open() as strm:

--- a/zipp.py
+++ b/zipp.py
@@ -205,7 +205,8 @@ class Path:
 
     Coercion to string:
 
-    >>> str(c)
+    >>> import os
+    >>> str(c).replace(os.sep, posixpath.sep)
     'mem/abcde.zip/b/c.txt'
 
     At the root, ``name``, ``filename``, and ``parent``
@@ -215,7 +216,7 @@ class Path:
 
     >>> root.name
     'abcde.zip'
-    >>> str(root.filename)
+    >>> str(root.filename).replace(os.sep, posixpath.sep)
     'mem/abcde.zip'
     >>> str(root.parent)
     'mem'

--- a/zipp.py
+++ b/zipp.py
@@ -9,6 +9,12 @@ import posixpath
 import zipfile
 import functools
 
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
+
+
 __metaclass__ = type
 
 
@@ -104,14 +110,11 @@ class Path:
 
     @property
     def name(self):
-        return posixpath.basename(self.at.rstrip("/")) \
-            or os.path.basename(self._root_filename())
+        return self.filename.name
 
-    def _root_filename(self):
-        value = self.root.filename
-        if value is None:
-            raise ValueError("Zip file has no filename")
-        return value
+    @property
+    def filename(self):
+        return pathlib.Path(self.root.filename).joinpath(self.at)
 
     def read_text(self, *args, **kwargs):
         with self.open() as strm:
@@ -167,6 +170,8 @@ class Path:
 
     @property
     def parent(self):
+        if not self.at:
+            return self.filename.parent
         parent_at = posixpath.dirname(self.at.rstrip('/'))
         if parent_at:
             parent_at += '/'

--- a/zipp.py
+++ b/zipp.py
@@ -162,7 +162,7 @@ class Path:
     >>> zf.writestr('a.txt', 'content of a')
     >>> zf.writestr('b/c.txt', 'content of c')
     >>> zf.writestr('b/d/e.txt', 'content of e')
-    >>> zf.filename = 'abcde.zip'
+    >>> zf.filename = 'mem/abcde.zip'
 
     Path accepts the zipfile object itself or a filename
 
@@ -174,9 +174,9 @@ class Path:
 
     >>> a, b = root.iterdir()
     >>> a
-    Path('abcde.zip', 'a.txt')
+    Path('mem/abcde.zip', 'a.txt')
     >>> b
-    Path('abcde.zip', 'b/')
+    Path('mem/abcde.zip', 'b/')
 
     name property:
 
@@ -187,7 +187,7 @@ class Path:
 
     >>> c = b / 'c.txt'
     >>> c
-    Path('abcde.zip', 'b/c.txt')
+    Path('mem/abcde.zip', 'b/c.txt')
     >>> c.name
     'c.txt'
 
@@ -206,7 +206,19 @@ class Path:
     Coercion to string:
 
     >>> str(c)
-    'abcde.zip/b/c.txt'
+    'mem/abcde.zip/b/c.txt'
+
+    At the root, ``name``, ``filename``, and ``parent``
+    resolve to the zipfile. Note these attributes are not
+    valid and will raise a ``ValueError`` if the zipfile
+    has no filename.
+
+    >>> root.name
+    'abcde.zip'
+    >>> str(root.filename)
+    'mem/abcde.zip'
+    >>> str(root.parent)
+    'mem'
     """
 
     __repr = "{self.__class__.__name__}({self.root.filename!r}, {self.at!r})"

--- a/zipp.py
+++ b/zipp.py
@@ -110,7 +110,7 @@ class Path:
 
     @property
     def name(self):
-        return self.filename.name
+        return pathlib.Path(self.at).name or self.filename.name
 
     @property
     def filename(self):


### PR DESCRIPTION
This PR builds on #10 by also exposing a `.filename` attribute, which is invalid when the underlying zipfile has no filename.

My main hesitation with this approach is it adds a dependency on pathlib. But even if that's acceptable, I'm also uneasy about the irregularity of the approach.

I'm also concerned about the use of pathlib in platform compatibility. I need to be sure I'm using the right pathlib classes (Path vs PurePath vs PurePosixPath).

I think I'm going to have to ponder this more.