### PR TITLE
Added constraint to more-itertools for 2/3 compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7
 install_requires =
-	more_itertools
+	more_itertools <= 5.0.0
 setup_requires = setuptools_scm >= 1.15.0
 
 [options.extras_require]


### PR DESCRIPTION
more-itertools is python 3.4 and above.

Looking at the changes between 5.0.0 and 7.2.0, no changes were made to unique_everseen (besides documentation), so this constraint will not change behaviour at all.