### PR TITLE
Limit version of more_itertools to 5.0.0 for python 2.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,9 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7
 install_requires =
-	more_itertools
+	more_itertools<=5.0.0; python_version<'3.0'
+	more_itertools; python_version>'3.0'
+
 setup_requires = setuptools_scm >= 1.15.0
 
 [options.extras_require]


### PR DESCRIPTION
more_itertools dropped python 2.7 support from version 6.0.0 on, hence to correctly resolve dependencies for python 2.7 the version needs to be limited.