### PR TITLE
added license line in metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ license_file = LICENSE
 name = zipp
 author = Jason R. Coombs
 author_email = jaraco@jaraco.com
+license: MIT
 description = Backport of pathlib-compatible object wrapper for zip files
 long_description = file:README.rst
 url = https://github.com/jaraco/zipp


### PR DESCRIPTION
pip-licenses is unable to locate the license metadata