### PR TITLE
Limits more-itertools to version 5.x.x in Python 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7
 install_requires =
-	more_itertools
+	more-itertools>=5.0.0,<6.0.0;python_version<="2.7"
+    more-itertools;python_version>"2.7"
 setup_requires = setuptools_scm >= 1.15.0
 
 [options.extras_require]


### PR DESCRIPTION
more-itertools stopped supporting Python 2 in version 6.0.0.
I'm not sure if there is a upper limit to set in the case of Python 3 so
I didn't set one. This preserves the old behavior.