### PR TITLE
Install wheel.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ tox_pip_extensions_ext_venv_update = true
 [testenv]
 deps =
 	setuptools>=31.0.1
+	wheel
 commands =
 	python -m unittest discover
 usedevelop = True


### PR DESCRIPTION
I noticed that recent PRs builds are breaking due to a missing wheel package.
```
Obtaining file:///home/travis/build/jaraco/zipp
    Complete output from command python setup.py egg_info:
    WARNING: The wheel package is not available.
    ERROR: 'pip wheel' requires the 'wheel' package. To fix this, run: pip install wheel
    Traceback (most recent call last):
      File "/home/travis/build/jaraco/zipp/.tox/python/lib/python3.5/site-packages/setuptools/installer.py", line 128, in fetch_build_egg
        subprocess.check_call(cmd)
      File "/opt/python/3.5.6/lib/python3.5/subprocess.py", line 271, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['/home/travis/build/jaraco/zipp/.tox/python/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmp0043t0qw', '--quiet', 'setuptools_scm>=1.15.0']' returned non-zero exit status 1
```