### PR TITLE
Add toml to setup_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,9 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
 	more_itertools
-setup_requires = setuptools_scm >= 3.4
+setup_requires =
+    setuptools_scm >= 3.4
+    toml
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
EDITED!

This PR makes toml available to setuptools add build time.  This should fix an issue that would result in distributions with the version `0.0.0`.