### PR TITLE
Linear lookup performance for read-only files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ testing =
 	# upstream
 
 	# local
+	jaraco.itertools
 
 docs =
 	# upstream

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -204,7 +204,7 @@ class TestPath(unittest.TestCase):
             baz, = (root / 'bar').iterdir()
             assert baz.read_text() == 'baz'
 
-    HUGE_ZIPFILE_NUM_ENTRIES = 50000
+    HUGE_ZIPFILE_NUM_ENTRIES = 2 ** 13
 
     def huge_zipfile(self):
         """Create a read-only zipfile with a huge number of entries entries."""

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -188,14 +188,14 @@ class TestPath(unittest.TestCase):
     HUGE_ZIPFILE_NUM_ENTRIES = 50000
 
     def huge_zipfile(self):
-        """Create an on-disk zipfile with a huge number of entries entries."""
-        tmpfile = pathlib.Path(self.fixtures.enter_context(temp_dir())) / 'huge.zip'
-        zf = zipfile.ZipFile(tmpfile, "w")
-        for x in range(0, self.HUGE_ZIPFILE_NUM_ENTRIES):
-            x_str = str(x)
-            zf.writestr(x_str, x_str.encode('ascii'))
+        """Create a read-only zipfile with a huge number of entries entries."""
+        strm = io.BytesIO()
+        zf = zipfile.ZipFile(strm, "w")
+        for entry in map(str, range(self.HUGE_ZIPFILE_NUM_ENTRIES)):
+            zf.writestr(entry, entry)
         zf.close()
-        yield str(tmpfile)
+        zf.mode = 'r'
+        yield zf
 
     def test_joinpath_constant_time(self):
         """

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -18,7 +18,7 @@ def add_dirs(zf):
     Given a writable zip file zf, inject directory entries for
     any directories implied by the presence of children.
     """
-    for name in zipp.FastZip._implied_dirs(zf.namelist()):
+    for name in zipp.CompleteDirs._implied_dirs(zf.namelist()):
         zf.writestr(name, b"")
     return zf
 

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -184,3 +184,28 @@ class TestPath(unittest.TestCase):
         for alpharep in self.zipfile_alpharep():
             root = zipp.Path(alpharep)
             assert (root / 'missing dir/').parent.at == ''
+
+    HUGE_ZIPFILE_NUM_ENTRIES = 50000
+
+    def huge_zipfile(self):
+        """Create an on-disk zipfile with a huge number of entries entries."""
+        tmpfile = pathlib.Path(self.fixtures.enter_context(temp_dir())) / 'huge.zip'
+        zf = zipfile.ZipFile(tmpfile, "w")
+        for x in range(0, self.HUGE_ZIPFILE_NUM_ENTRIES):
+            x_str = str(x)
+            zf.writestr(x_str, x_str.encode('ascii'))
+        zf.close()
+        yield str(tmpfile)
+
+    def test_joinpath_constant_time(self):
+        """
+        Ensure joinpath on items in zipfile is linear time.
+        """
+        for huge_zipfile in self.huge_zipfile():
+            root = zipp.Path(huge_zipfile)
+            n = 0
+            for entry in root.iterdir():
+                entry.joinpath('suffix')
+                n += 1
+            # Check the file iterated all items
+            assert n == self.HUGE_ZIPFILE_NUM_ENTRIES

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -18,7 +18,7 @@ def add_dirs(zf):
     Given a writable zip file zf, inject directory entries for
     any directories implied by the presence of children.
     """
-    for name in zipp.Path._implied_dirs(zf.namelist()):
+    for name in zipp.FastZip._implied_dirs(zf.namelist()):
         zf.writestr(name, b"")
     return zf
 

--- a/zipp.py
+++ b/zipp.py
@@ -68,9 +68,9 @@ class CompleteDirs(zipfile.ZipFile):
 
     def find(self, name):
         names = self._name_set()
-        if name not in names and name + '/' in names:
-            return name + '/'
-        return name
+        dirname = name + '/'
+        dir_match = name not in names and dirname in names
+        return dirname if dir_match else name
 
 
 class FastZip(CompleteDirs):

--- a/zipp.py
+++ b/zipp.py
@@ -49,6 +49,11 @@ def _ancestry(path):
 
 
 class CompleteDirs(zipfile.ZipFile):
+    """
+    A ZipFile subclass that ensures that implied directories
+    are always included in the namelist.
+    """
+
     @staticmethod
     def _implied_dirs(names):
         parents = itertools.chain.from_iterable(map(_parents, names))
@@ -67,7 +72,11 @@ class CompleteDirs(zipfile.ZipFile):
     def _name_set(self):
         return set(self.namelist())
 
-    def find(self, name):
+    def resolve_dir(self, name):
+        """
+        If the name represents a directory, return that name
+        as a directory (with the trailing slash).
+        """
         names = self._name_set()
         dirname = name + '/'
         dir_match = name not in names and dirname in names
@@ -95,7 +104,7 @@ class FastZip(CompleteDirs):
     def make(cls, source):
         """
         Given a source (filename or zipfile), return an
-        appropriate subclass.
+        appropriate CompleteDirs subclass.
         """
         if isinstance(source, CompleteDirs):
             return source
@@ -239,7 +248,7 @@ class Path:
 
     def joinpath(self, add):
         next = posixpath.join(self.at, _pathlib_compat(add))
-        return self._next(self.root.find(next))
+        return self._next(self.root.resolve_dir(next))
 
     __truediv__ = joinpath
 

--- a/zipp.py
+++ b/zipp.py
@@ -97,11 +97,15 @@ class FastZip(CompleteDirs):
         Given a source (filename or zipfile), return an
         appropriate subclass.
         """
-        if isinstance(source, cls):
+        if isinstance(source, CompleteDirs):
             return source
 
         if not isinstance(source, zipfile.ZipFile):
             return cls(_pathlib_compat(source))
+
+        # Only allow for FastPath when supplied zipfile is read-only
+        if 'r' not in source.mode:
+            cls = CompleteDirs
 
         res = cls.__new__(cls)
         vars(res).update(vars(source))

--- a/zipp.py
+++ b/zipp.py
@@ -232,7 +232,7 @@ class Path:
         return not self.is_dir()
 
     def exists(self):
-        return self.at in self.root.namelist()
+        return self.at in self.root._name_set()
 
     def iterdir(self):
         if not self.is_dir():

--- a/zipp.py
+++ b/zipp.py
@@ -82,24 +82,6 @@ class CompleteDirs(zipfile.ZipFile):
         dir_match = name not in names and dirname in names
         return dirname if dir_match else name
 
-
-class FastZip(CompleteDirs):
-    """
-    ZipFile subclass to ensure implicit
-    dirs exist and are resolved rapidly.
-    """
-    def namelist(self):
-        with contextlib.suppress(AttributeError):
-            return self.__names
-        self.__names = super().namelist()
-        return self.__names
-
-    def _name_set(self):
-        with contextlib.suppress(AttributeError):
-            return self.__lookup
-        self.__lookup = super()._name_set()
-        return self.__lookup
-
     @classmethod
     def make(cls, source):
         """
@@ -119,6 +101,24 @@ class FastZip(CompleteDirs):
         res = cls.__new__(cls)
         vars(res).update(vars(source))
         return res
+
+
+class FastZip(CompleteDirs):
+    """
+    ZipFile subclass to ensure implicit
+    dirs exist and are resolved rapidly.
+    """
+    def namelist(self):
+        with contextlib.suppress(AttributeError):
+            return self.__names
+        self.__names = super().namelist()
+        return self.__names
+
+    def _name_set(self):
+        with contextlib.suppress(AttributeError):
+            return self.__lookup
+        self.__lookup = super()._name_set()
+        return self.__lookup
 
 
 def _pathlib_compat(path):

--- a/zipp.py
+++ b/zipp.py
@@ -103,7 +103,7 @@ class CompleteDirs(zipfile.ZipFile):
         return res
 
 
-class FastZip(CompleteDirs):
+class FastLookup(CompleteDirs):
     """
     ZipFile subclass to ensure implicit
     dirs exist and are resolved rapidly.
@@ -200,7 +200,7 @@ class Path:
     __repr = "{self.__class__.__name__}({self.root.filename!r}, {self.at!r})"
 
     def __init__(self, root, at=""):
-        self.root = FastZip.make(root)
+        self.root = FastLookup.make(root)
         self.at = at
 
     @property

--- a/zipp.py
+++ b/zipp.py
@@ -47,19 +47,19 @@ def _ancestry(path):
         path, tail = posixpath.split(path)
 
 
-class FastZip:
+class FastZip(zipfile.ZipFile):
     """
-    Wrapper around a zipfile.ZipFile to ensure implicit
+    ZipFile subclass to ensure implicit
     dirs exist and are resolved rapidly.
     """
-    def __init__(self, zipfile):
-        self.zipfile = zipfile
-        self.__names = zipfile.namelist()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__setup_caches()
+
+    def __setup_caches(self):
+        self.__names = super().namelist()
         self.__names += self._implied_dirs(self.__names)
         self.__lookup = set(self.__names)
-
-    def __getattr__(self, *args, **kwargs):
-        return getattr(self.zipfile, *args, **kwargs)
 
     def find(self, name):
         if name not in self.__lookup and name + '/' in self.__lookup:
@@ -79,6 +79,34 @@ class FastZip:
 
     def namelist(self):
         return self.__names
+
+    @classmethod
+    def make(cls, source):
+        """
+        Given a source (filename or zipfile), return an
+        appropriate subclass.
+        """
+        if isinstance(source, cls):
+            return source
+
+        if not isinstance(source, zipfile.ZipFile):
+            return cls(_pathlib_compat(source))
+
+        res = cls.__new__(cls)
+        vars(res).update(vars(source))
+        res.__setup_caches()
+        return res
+
+
+def _pathlib_compat(path):
+    """
+    For path-like objects, convert to a filename for compatibility
+    on Python 3.6.1 and earlier.
+    """
+    try:
+        return path.__fspath__()
+    except AttributeError:
+        return str(path)
 
 
 class Path:
@@ -149,27 +177,8 @@ class Path:
     __repr = "{self.__class__.__name__}({self.root.filename!r}, {self.at!r})"
 
     def __init__(self, root, at=""):
-        self.root = (
-            root
-            if isinstance(root, FastZip) else
-            FastZip(
-                root
-                if isinstance(root, zipfile.ZipFile)
-                else zipfile.ZipFile(self._pathlib_compat(root))
-            )
-        )
+        self.root = FastZip.make(root)
         self.at = at
-
-    @staticmethod
-    def _pathlib_compat(path):
-        """
-        For path-like objects, convert to a filename for compatibility
-        on Python 3.6.1 and earlier.
-        """
-        try:
-            return path.__fspath__()
-        except AttributeError:
-            return str(path)
 
     @property
     def open(self):
@@ -215,8 +224,7 @@ class Path:
         return self.__repr.format(self=self)
 
     def joinpath(self, add):
-        add = self._pathlib_compat(add)
-        next = posixpath.join(self.at, add)
+        next = posixpath.join(self.at, _pathlib_compat(add))
         return self._next(self.root.find(next))
 
     __truediv__ = joinpath

--- a/zipp.py
+++ b/zipp.py
@@ -3,6 +3,7 @@ import posixpath
 import zipfile
 import functools
 import itertools
+import contextlib
 from collections import OrderedDict
 
 
@@ -78,18 +79,16 @@ class FastZip(CompleteDirs):
     ZipFile subclass to ensure implicit
     dirs exist and are resolved rapidly.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__setup_caches()
-
-    def __setup_caches(self):
-        self.__names = super().namelist()
-        self.__lookup = super()._name_set()
-
     def namelist(self):
+        with contextlib.suppress(AttributeError):
+            return self.__names
+        self.__names = super().namelist()
         return self.__names
 
     def _name_set(self):
+        with contextlib.suppress(AttributeError):
+            return self.__lookup
+        self.__lookup = super()._name_set()
         return self.__lookup
 
     @classmethod
@@ -106,7 +105,6 @@ class FastZip(CompleteDirs):
 
         res = cls.__new__(cls)
         vars(res).update(vars(source))
-        res.__setup_caches()
         return res
 
 

--- a/zipp.py
+++ b/zipp.py
@@ -47,25 +47,7 @@ def _ancestry(path):
         path, tail = posixpath.split(path)
 
 
-class FastZip(zipfile.ZipFile):
-    """
-    ZipFile subclass to ensure implicit
-    dirs exist and are resolved rapidly.
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__setup_caches()
-
-    def __setup_caches(self):
-        self.__names = super().namelist()
-        self.__names += self._implied_dirs(self.__names)
-        self.__lookup = set(self.__names)
-
-    def find(self, name):
-        if name not in self.__lookup and name + '/' in self.__lookup:
-            return name + '/'
-        return name
-
+class CompleteDirs(zipfile.ZipFile):
     @staticmethod
     def _implied_dirs(names):
         parents = itertools.chain.from_iterable(map(_parents, names))
@@ -78,7 +60,37 @@ class FastZip(zipfile.ZipFile):
         return implied_dirs
 
     def namelist(self):
+        names = super().namelist()
+        return names + list(self._implied_dirs(names))
+
+    def _name_set(self):
+        return set(self.namelist())
+
+    def find(self, name):
+        names = self._name_set()
+        if name not in names and name + '/' in names:
+            return name + '/'
+        return name
+
+
+class FastZip(CompleteDirs):
+    """
+    ZipFile subclass to ensure implicit
+    dirs exist and are resolved rapidly.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__setup_caches()
+
+    def __setup_caches(self):
+        self.__names = super().namelist()
+        self.__lookup = super()._name_set()
+
+    def namelist(self):
         return self.__names
+
+    def _name_set(self):
+        return self.__lookup
 
     @classmethod
     def make(cls, source):

--- a/zipp.py
+++ b/zipp.py
@@ -47,6 +47,40 @@ def _ancestry(path):
         path, tail = posixpath.split(path)
 
 
+class FastZip:
+    """
+    Wrapper around a zipfile.ZipFile to ensure implicit
+    dirs exist and are resolved rapidly.
+    """
+    def __init__(self, zipfile):
+        self.zipfile = zipfile
+        self.__names = zipfile.namelist()
+        self.__names += self._implied_dirs(self.__names)
+        self.__lookup = set(self.__names)
+
+    def __getattr__(self, *args, **kwargs):
+        return getattr(self.zipfile, *args, **kwargs)
+
+    def find(self, name):
+        if name not in self.__lookup and name + '/' in self.__lookup:
+            return name + '/'
+        return name
+
+    @staticmethod
+    def _implied_dirs(names):
+        parents = itertools.chain.from_iterable(map(_parents, names))
+        # Deduplicate entries in original order
+        implied_dirs = OrderedDict.fromkeys(
+            p + posixpath.sep for p in parents
+            # Cast names to a set for O(1) lookups
+            if p + posixpath.sep not in set(names)
+        )
+        return implied_dirs
+
+    def namelist(self):
+        return self.__names
+
+
 class Path:
     """
     A pathlib-compatible interface for zip files.
@@ -117,8 +151,12 @@ class Path:
     def __init__(self, root, at=""):
         self.root = (
             root
-            if isinstance(root, zipfile.ZipFile)
-            else zipfile.ZipFile(self._pathlib_compat(root))
+            if isinstance(root, FastZip) else
+            FastZip(
+                root
+                if isinstance(root, zipfile.ZipFile)
+                else zipfile.ZipFile(self._pathlib_compat(root))
+            )
         )
         self.at = at
 
@@ -162,12 +200,12 @@ class Path:
         return not self.is_dir()
 
     def exists(self):
-        return self.at in self._names()
+        return self.at in self.root.namelist()
 
     def iterdir(self):
         if not self.is_dir():
             raise ValueError("Can't listdir a file")
-        subs = map(self._next, self._names())
+        subs = map(self._next, self.root.namelist())
         return filter(self._is_child, subs)
 
     def __str__(self):
@@ -179,26 +217,9 @@ class Path:
     def joinpath(self, add):
         add = self._pathlib_compat(add)
         next = posixpath.join(self.at, add)
-        next_dir = posixpath.join(self.at, add, "")
-        names = self._names()
-        return self._next(next_dir if next not in names and next_dir in names else next)
+        return self._next(self.root.find(next))
 
     __truediv__ = joinpath
-
-    @staticmethod
-    def _implied_dirs(names):
-        parents = itertools.chain.from_iterable(map(_parents, names))
-        # Deduplicate entries in original order
-        implied_dirs = OrderedDict.fromkeys(
-            p + posixpath.sep for p in parents
-            # Cast names to a set for O(1) lookups
-            if p + posixpath.sep not in set(names)
-        )
-        return iter(implied_dirs)
-
-    @classmethod
-    def _add_implied_dirs(cls, names):
-        return names + list(cls._implied_dirs(names))
 
     @property
     def parent(self):
@@ -206,6 +227,3 @@ class Path:
         if parent_at:
             parent_at += '/'
         return self._next(parent_at)
-
-    def _names(self):
-        return self._add_implied_dirs(self.root.namelist())


### PR DESCRIPTION
Building on the work from #33, this approach abstracts and encapsulates two behaviors into new CompleteDirs and FastLookup classes. This approach has these benefits over #33:

- better separation of concerns
- order is maintained
- tests run faster
- avoids on-disk zip files
- avoids ordering Path objects