### PR TITLE
Linear lookup for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: python
 
 python:
 - 2.7
-- 3.5
-- &latest_py3 3.7
+- 3.6
+- &latest_py3 3.8
 
 jobs:
   fast_finish: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+v1.1.0
+======
+
+#32: For read-only zip files, complexity of ``.exists`` and
+``joinpath`` is now constant time instead of ``O(n)``, preventing
+quadratic time in common use-cases and rendering large
+zip files unusable for Path. Big thanks to Benjy Weinberger
+for the bug report and contributed fix (#33).
+
 v1.0.0
 ======
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ testing =
 	pathlib2
 	contextlib2
 	unittest2
+	jaraco.itertools
 
 docs =
 	# upstream

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7
 install_requires =
-	more_itertools
+	contextlib2; python_version < "3.4"
 setup_requires = setuptools_scm >= 1.15.0
 
 [options.extras_require]
@@ -31,7 +31,6 @@ testing =
 
 	# local
 	pathlib2
-	contextlib2
 	unittest2
 	jaraco.itertools
 

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -200,14 +200,14 @@ class TestPath(unittest.TestCase):
     HUGE_ZIPFILE_NUM_ENTRIES = 50000
 
     def huge_zipfile(self):
-        """Create an on-disk zipfile with a huge number of entries entries."""
-        tmpfile = pathlib.Path(self.fixtures.enter_context(temp_dir())) / 'huge.zip'
-        zf = zipfile.ZipFile(tmpfile, "w")
-        for x in range(0, self.HUGE_ZIPFILE_NUM_ENTRIES):
-            x_str = str(x)
-            zf.writestr(x_str, x_str.encode('ascii'))
+        """Create a read-only zipfile with a huge number of entries entries."""
+        strm = io.BytesIO()
+        zf = zipfile.ZipFile(strm, "w")
+        for entry in map(str, range(self.HUGE_ZIPFILE_NUM_ENTRIES)):
+            zf.writestr(entry, entry)
         zf.close()
-        yield str(tmpfile)
+        zf.mode = 'r'
+        yield zf
 
     def test_joinpath_constant_time(self):
         """

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -38,7 +38,7 @@ def add_dirs(zf):
     Given a writable zip file zf, inject directory entries for
     any directories implied by the presence of children.
     """
-    for name in zipp.FastZip._implied_dirs(zf.namelist()):
+    for name in zipp.CompleteDirs._implied_dirs(zf.namelist()):
         zf.writestr(name, b"")
     return zf
 

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -199,7 +199,24 @@ class TestPath(unittest.TestCase):
             root = zipp.Path(alpharep)
             assert (root / 'missing dir/').parent.at == ''
 
-    HUGE_ZIPFILE_NUM_ENTRIES = 50000
+    def test_mutability(self):
+        """
+        If the underlying zipfile is changed, the Path object should
+        reflect that change.
+        """
+        for alpharep in self.zipfile_alpharep():
+            root = zipp.Path(alpharep)
+            a, b, g = root.iterdir()
+            alpharep.writestr('foo.txt', 'foo')
+            alpharep.writestr('bar/baz.txt', 'baz')
+            assert any(
+                child.name == 'foo.txt'
+                for child in root.iterdir())
+            assert (root / 'foo.txt').read_text() == 'foo'
+            baz, = (root / 'bar').iterdir()
+            assert baz.read_text() == 'baz'
+
+    HUGE_ZIPFILE_NUM_ENTRIES = 2 ** 13
 
     def huge_zipfile(self):
         """Create a read-only zipfile with a huge number of entries entries."""

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -25,6 +25,8 @@ try:
 except AttributeError:
     import unittest2 as unittest
 
+import jaraco.itertools
+
 import zipp
 
 __metaclass__ = type
@@ -205,19 +207,16 @@ class TestPath(unittest.TestCase):
         zf = zipfile.ZipFile(strm, "w")
         for entry in map(str, range(self.HUGE_ZIPFILE_NUM_ENTRIES)):
             zf.writestr(entry, entry)
-        zf.close()
         zf.mode = 'r'
-        yield zf
+        return zf
 
     def test_joinpath_constant_time(self):
         """
         Ensure joinpath on items in zipfile is linear time.
         """
-        for huge_zipfile in self.huge_zipfile():
-            root = zipp.Path(huge_zipfile)
-            n = 0
-            for entry in root.iterdir():
-                entry.joinpath('suffix')
-                n += 1
-            # Check the file iterated all items
-            assert n == self.HUGE_ZIPFILE_NUM_ENTRIES
+        root = zipp.Path(self.huge_zipfile())
+        entries = jaraco.itertools.Counter(root.iterdir())
+        for entry in entries:
+            entry.joinpath('suffix')
+        # Check the file iterated all items
+        assert entries.count == self.HUGE_ZIPFILE_NUM_ENTRIES

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -38,7 +38,7 @@ def add_dirs(zf):
     Given a writable zip file zf, inject directory entries for
     any directories implied by the presence of children.
     """
-    for name in zipp.Path._implied_dirs(zf.namelist()):
+    for name in zipp.FastZip._implied_dirs(zf.namelist()):
         zf.writestr(name, b"")
     return zf
 

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -4,7 +4,6 @@ from __future__ import division, unicode_literals
 
 import io
 import zipfile
-import posixpath
 import contextlib
 import tempfile
 import shutil
@@ -207,8 +206,8 @@ class TestPath(unittest.TestCase):
         for alpharep in self.zipfile_alpharep():
             root = zipp.Path(alpharep)
             a, b, g = root.iterdir()
-            alpharep.writestr('foo.txt', 'foo')
-            alpharep.writestr('bar/baz.txt', 'baz')
+            alpharep.writestr('foo.txt', b'foo')
+            alpharep.writestr('bar/baz.txt', b'baz')
             assert any(
                 child.name == 'foo.txt'
                 for child in root.iterdir())

--- a/zipp.py
+++ b/zipp.py
@@ -60,6 +60,11 @@ def _ancestry(path):
 
 
 class CompleteDirs(zipfile.ZipFile):
+    """
+    A ZipFile subclass that ensures that implied directories
+    are always included in the namelist.
+    """
+
     @staticmethod
     def _implied_dirs(names):
         parents = itertools.chain.from_iterable(map(_parents, names))
@@ -78,7 +83,11 @@ class CompleteDirs(zipfile.ZipFile):
     def _name_set(self):
         return set(self.namelist())
 
-    def find(self, name):
+    def resolve_dir(self, name):
+        """
+        If the name represents a directory, return that name
+        as a directory (with the trailing slash).
+        """
         names = self._name_set()
         dirname = name + '/'
         dir_match = name not in names and dirname in names
@@ -106,7 +115,7 @@ class FastZip(CompleteDirs):
     def make(cls, source):
         """
         Given a source (filename or zipfile), return an
-        appropriate subclass.
+        appropriate CompleteDirs subclass.
         """
         if isinstance(source, CompleteDirs):
             return source
@@ -250,7 +259,7 @@ class Path:
 
     def joinpath(self, add):
         next = posixpath.join(self.at, _pathlib_compat(add))
-        return self._next(self.root.find(next))
+        return self._next(self.root.resolve_dir(next))
 
     __truediv__ = joinpath
 

--- a/zipp.py
+++ b/zipp.py
@@ -93,24 +93,6 @@ class CompleteDirs(zipfile.ZipFile):
         dir_match = name not in names and dirname in names
         return dirname if dir_match else name
 
-
-class FastZip(CompleteDirs):
-    """
-    ZipFile subclass to ensure implicit
-    dirs exist and are resolved rapidly.
-    """
-    def namelist(self):
-        with suppress(AttributeError):
-            return self.__names
-        self.__names = super().namelist()
-        return self.__names
-
-    def _name_set(self):
-        with suppress(AttributeError):
-            return self.__lookup
-        self.__lookup = super()._name_set()
-        return self.__lookup
-
     @classmethod
     def make(cls, source):
         """
@@ -130,6 +112,24 @@ class FastZip(CompleteDirs):
         res = cls.__new__(cls)
         vars(res).update(vars(source))
         return res
+
+
+class FastZip(CompleteDirs):
+    """
+    ZipFile subclass to ensure implicit
+    dirs exist and are resolved rapidly.
+    """
+    def namelist(self):
+        with suppress(AttributeError):
+            return self.__names
+        self.__names = super().namelist()
+        return self.__names
+
+    def _name_set(self):
+        with suppress(AttributeError):
+            return self.__lookup
+        self.__lookup = super()._name_set()
+        return self.__lookup
 
 
 def _pathlib_compat(path):

--- a/zipp.py
+++ b/zipp.py
@@ -77,7 +77,7 @@ class CompleteDirs(zipfile.ZipFile):
         return implied_dirs
 
     def namelist(self):
-        names = super().namelist()
+        names = super(CompleteDirs, self).namelist()
         return names + list(self._implied_dirs(names))
 
     def _name_set(self):
@@ -122,13 +122,13 @@ class FastLookup(CompleteDirs):
     def namelist(self):
         with suppress(AttributeError):
             return self.__names
-        self.__names = super().namelist()
+        self.__names = super(FastLookup, self).namelist()
         return self.__names
 
     def _name_set(self):
         with suppress(AttributeError):
             return self.__lookup
-        self.__lookup = super()._name_set()
+        self.__lookup = super(FastLookup, self)._name_set()
         return self.__lookup
 
 

--- a/zipp.py
+++ b/zipp.py
@@ -114,7 +114,7 @@ class CompleteDirs(zipfile.ZipFile):
         return res
 
 
-class FastZip(CompleteDirs):
+class FastLookup(CompleteDirs):
     """
     ZipFile subclass to ensure implicit
     dirs exist and are resolved rapidly.
@@ -211,7 +211,7 @@ class Path:
     __repr = "{self.__class__.__name__}({self.root.filename!r}, {self.at!r})"
 
     def __init__(self, root, at=""):
-        self.root = FastZip.make(root)
+        self.root = FastLookup.make(root)
         self.at = at
 
     @property

--- a/zipp.py
+++ b/zipp.py
@@ -8,8 +8,12 @@ import posixpath
 import zipfile
 import functools
 import itertools
+from collections import OrderedDict
 
-import more_itertools
+try:
+    from contextlib import suppress
+except ImportError:
+    from contextlib2 import suppress
 
 __metaclass__ = type
 
@@ -86,18 +90,16 @@ class FastZip(CompleteDirs):
     ZipFile subclass to ensure implicit
     dirs exist and are resolved rapidly.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__setup_caches()
-
-    def __setup_caches(self):
-        self.__names = super().namelist()
-        self.__lookup = super()._name_set()
-
     def namelist(self):
+        with suppress(AttributeError):
+            return self.__names
+        self.__names = super().namelist()
         return self.__names
 
     def _name_set(self):
+        with suppress(AttributeError):
+            return self.__lookup
+        self.__lookup = super()._name_set()
         return self.__lookup
 
     @classmethod
@@ -114,7 +116,6 @@ class FastZip(CompleteDirs):
 
         res = cls.__new__(cls)
         vars(res).update(vars(source))
-        res.__setup_caches()
         return res
 
 

--- a/zipp.py
+++ b/zipp.py
@@ -243,7 +243,7 @@ class Path:
         return not self.is_dir()
 
     def exists(self):
-        return self.at in self.root.namelist()
+        return self.at in self.root._name_set()
 
     def iterdir(self):
         if not self.is_dir():

--- a/zipp.py
+++ b/zipp.py
@@ -76,9 +76,9 @@ class CompleteDirs(zipfile.ZipFile):
 
     def find(self, name):
         names = self._name_set()
-        if name not in names and name + '/' in names:
-            return name + '/'
-        return name
+        dirname = name + '/'
+        dir_match = name not in names and dirname in names
+        return dirname if dir_match else name
 
 
 class FastZip(CompleteDirs):

--- a/zipp.py
+++ b/zipp.py
@@ -108,11 +108,15 @@ class FastZip(CompleteDirs):
         Given a source (filename or zipfile), return an
         appropriate subclass.
         """
-        if isinstance(source, cls):
+        if isinstance(source, CompleteDirs):
             return source
 
         if not isinstance(source, zipfile.ZipFile):
             return cls(_pathlib_compat(source))
+
+        # Only allow for FastPath when supplied zipfile is read-only
+        if 'r' not in source.mode:
+            cls = CompleteDirs
 
         res = cls.__new__(cls)
         vars(res).update(vars(source))


### PR DESCRIPTION
Building on #34, this change backports the functionality to Python 2, suitable for merging to the maint/1.x branch and releasing for compatibility.