### PR TITLE
setup.cfg: let python-tag mirror python_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,9 @@ classifiers =
 	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3 :: Only
 
+[bdist_wheel]
+python-tag=py36
+
 [options]
 py_modules = zipp
 packages = find:


### PR DESCRIPTION
In order to generate a wheel in accordance with PEP 425 to restrict the
minimum required version of Python (3.6), the `python-tag` bdist_wheel
option needs to be specified so the wheel gets tagged properly.

Before:
	zipp-x.x.x-py3-none-any.whl
After:
	zipp-x.x.x-py36-none-any.whl

Signed-off-by: Vincent Fazio <vfazio@xes-inc.com>

closes #36