### PR TITLE
Reenable python3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ dist: xenial
 language: python
 
 python:
-- 3.6
+- 3.5
 - &latest_py3 3.8
 
 cache: pip
 
 install:
-- pip install tox tox-venv
+- pip install tox tox-venv wheel
 
 before_script:
   # Disable IPv6. Ref travis-ci/travis-ci#8361

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 
 python:
 - 3.5
+- 3.6
+- 3.7
 - &latest_py3 3.8
 
 cache: pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,9 @@ environment:
   APPVEYOR: true
 
   matrix:
+    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"
 
 install:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,8 +23,12 @@ stages:
   - job: 'Test'
     strategy:
       matrix:
+        Python35:
+          python.version: '3.5'
         Python36:
           python.version: '3.6'
+        Python37:
+          python.version: '3.7'
         Python38:
           python.version: '3.8'
       maxParallel: 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 py_modules = zipp
 packages = find:
 include_package_data = true
-python_requires = >=3.6
+python_requires = >=3.5
 install_requires =
 setup_requires = setuptools_scm[toml] >= 3.4.1
 


### PR DESCRIPTION
Reenable support for python 3.5. Python 3.5 is still supported until September 2020 and included in old stable distributions of debian (stretch). Deprecating support for older python versions not only break zipp on those platforms, but may also break pip install commands of other packages which list zipp as a dependency. Please also release a new version to pypi to ensure python3.5 can be used again in conjunction with zipp.

The first commit fixes the CI support by installing wheel explicitly and lowering the required python version to 3.5 again. The second commit enables support to also build 3.6 and 3.7.

Fixes https://github.com/jaraco/zipp/issues/38