### PR TITLE
Mutate the passed ZipFile object type instead of making a copy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+v3.2.0
+======
+
+#57 and bpo-40564: Mutate the passed ZipFile object
+type instead of making a copy. Prevents issues when
+both the local copy and the caller's copy attempt to
+close the same file handle.
+
 v3.1.0
 ======
 

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -259,3 +259,9 @@ class TestPath(unittest.TestCase):
     def test_implied_dirs_performance(self):
         data = ['/'.join(string.ascii_lowercase + str(n)) for n in range(10000)]
         zipp.CompleteDirs._implied_dirs(data)
+
+    def test_read_does_not_close(self):
+        for alpharep in self.zipfile_ondisk():
+            with zipfile.ZipFile(alpharep) as file:
+                for rep in range(2):
+                    zipp.Path(file, 'a.txt').read_text()

--- a/zipp.py
+++ b/zipp.py
@@ -210,6 +210,15 @@ class Path:
     __repr = "{self.__class__.__name__}({self.root.filename!r}, {self.at!r})"
 
     def __init__(self, root, at=""):
+        """
+        Construct a Path from a ZipFile or filename.
+
+        Note: When the source is an existing ZipFile object,
+        its type (__class__) will be mutated to a
+        specialized type. If the caller wishes to retain the
+        original type, the caller should either create a
+        separate ZipFile object or pass a filename.
+        """
         self.root = FastLookup.make(root)
         self.at = at
 

--- a/zipp.py
+++ b/zipp.py
@@ -109,9 +109,8 @@ class CompleteDirs(zipfile.ZipFile):
         if 'r' not in source.mode:
             cls = CompleteDirs
 
-        res = cls.__new__(cls)
-        vars(res).update(vars(source))
-        return res
+        source.__class__ = cls
+        return source
 
 
 class FastLookup(CompleteDirs):


### PR DESCRIPTION
Prevents issues when both the local copy and the caller's copy attempt to close the same file handle.

Fixes [bpo-40564](https://bugs.python.org/issue40564) and fixes #57.