### PR TITLE
Set use_scm_version to True in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,7 @@
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(
+        use_scm_version=True,
+        setup_requires=['setuptools_scm'],
+    )


### PR DESCRIPTION
For backward compatibility, 'use_scm_version' should be set to True in
setup.py as per [1].
When building this package in CentOS Build System, the version written
in zipp.egg-info/PKG-INFO was 0.0.0 (even though git binary was
available).
CBS is using old version of python-setuptools and python_setuptools_scm,
that's why it still depends on 'setup.cfg' usage.
With this change, the python command 'python setup.py --version' returns
the right version.

[1] https://github.com/pypa/setuptools_scm#setuppy-usage