### PR TITLE
Relax Python version requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 packages = find_namespace:
 py_modules = zipp
 include_package_data = true
-python_requires = >=3.7
+python_requires = >=3.6
 install_requires =
 
 [options.packages.find]


### PR DESCRIPTION
Python 3.6+ works nicely and is still used in many
supported Linux distros.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>