### PR TITLE
create lazy loading lookup class to support pickling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v3.9.0
+======
+
+* #81: ``Path`` objects are now pickleable if they've been
+  constructed from pickleable objects. Any restored objects
+  will re-construct the zip file with the original arguments.
+
 v3.8.1
 ======
 

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -7,6 +7,7 @@ import tempfile
 import shutil
 import string
 import functools
+import pickle
 
 import jaraco.itertools
 import func_timeout
@@ -416,3 +417,21 @@ class TestPath(unittest.TestCase):
         for alpharep in self.zipfile_alpharep():
             file = cls(alpharep).joinpath('some dir').parent
             assert isinstance(file, cls)
+
+    def test_can_pickle_string_path(self):     
+        try:
+            path_1 = zipp.Path("/path/to/a/file.zip")
+            path_1_pickle = pickle.dumps(path_1)
+            path_2 = zipp.Path("/path/to/a/file.zip", at="something.txt")
+            path_2_pickle = pickle.dumps(path_2)
+        except TypeError as exec:
+            assert False, "TypeError: Path is not pickleable"
+
+    def test_can_pickle_pathlib_path(self):
+        try:
+            path_1 = zipp.Path(pathlib.Path("/path/to/a/file.zip"))
+            path_1_pickle = pickle.dumps(path_1)
+            path_2 = zipp.Path(pathlib.Path("/path/to/a/file.zip", at="something.txt"))
+            path_2_pickle = pickle.dumps(path_2)
+        except TypeError as exec:
+            assert False, "TypeError: Path is not pickleable"

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -418,22 +418,30 @@ class TestPath(unittest.TestCase):
             file = cls(alpharep).joinpath('some dir').parent
             assert isinstance(file, cls)
 
-    def test_can_pickle_string_path(self):
-        path_1 = zipp.Path("/path/to/a/file.zip")
-        path_1_pickle = pickle.dumps(path_1)
-        path_1_load = pickle.loads(path_1_pickle)
-        assert path_1.root == path_1_load.root
-        path_2 = zipp.Path("/path/to/a/file.zip", at="something.txt")
-        path_2_pickle = pickle.dumps(path_2)
-        path_2_load = pickle.loads(path_2_pickle)
-        assert path_2.root == path_2_load.root
+    @pass_alpharep
+    def test_can_pickle_string_path(self, alpharep):
+        zipfile_ondisk = str(self.zipfile_ondisk(alpharep))
 
-    def test_can_pickle_pathlib_path(self):
-        path_1 = zipp.Path(pathlib.Path("/path/to/a/file.zip"))
-        path_1_pickle = pickle.dumps(path_1)
-        path_1_load = pickle.loads(path_1_pickle)
-        assert path_1.root == path_1_load.root
-        path_2 = zipp.Path(pathlib.Path("/path/to/a/file.zip", at="something.txt"))
-        path_2_pickle = pickle.dumps(path_2)
-        path_2_load = pickle.loads(path_2_pickle)
-        assert path_2.root == path_2_load.root
+        saved_1 = pickle.dumps(zipp.Path(zipfile_ondisk))
+        restored_1 = pickle.loads(saved_1)
+        a, b, g = restored_1.iterdir()
+        assert a.read_text() == "content of a"
+
+        saved_2 = pickle.dumps(zipp.Path(zipfile_ondisk, at="b/"))
+        restored_2 = pickle.loads(saved_2)
+        c, d, f = restored_2.iterdir()
+        assert c.read_text() == 'content of c'
+
+    @pass_alpharep
+    def test_can_pickle_pathlib_path(self, alpharep):
+        zipfile_ondisk = self.zipfile_ondisk(alpharep)
+
+        saved_1 = pickle.dumps(zipp.Path(zipfile_ondisk))
+        restored_1 = pickle.loads(saved_1)
+        a, b, g = restored_1.iterdir()
+        assert a.read_text() == "content of a"
+
+        saved_2 = pickle.dumps(zipp.Path(zipfile_ondisk, at="b/"))
+        restored_2 = pickle.loads(saved_2)
+        c, d, f = restored_2.iterdir()
+        assert c.read_text() == 'content of c'

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -419,27 +419,21 @@ class TestPath(unittest.TestCase):
             assert isinstance(file, cls)
 
     def test_can_pickle_string_path(self):     
-        try:
-            path_1 = zipp.Path("/path/to/a/file.zip")
-            path_1_pickle = pickle.dumps(path_1)
-            path_1_load = pickle.loads(path_1_pickle)
-            assert path_1.root == path_1_load.root
-            path_2 = zipp.Path("/path/to/a/file.zip", at="something.txt")
-            path_2_pickle = pickle.dumps(path_2)
-            path_2_load = pickle.loads(path_2_pickle)
-            assert path_2.root == path_2_load.root
-        except TypeError as exec:
-            assert False, "TypeError: Path is not pickleable"
+        path_1 = zipp.Path("/path/to/a/file.zip")
+        path_1_pickle = pickle.dumps(path_1)
+        path_1_load = pickle.loads(path_1_pickle)
+        assert path_1.root == path_1_load.root
+        path_2 = zipp.Path("/path/to/a/file.zip", at="something.txt")
+        path_2_pickle = pickle.dumps(path_2)
+        path_2_load = pickle.loads(path_2_pickle)
+        assert path_2.root == path_2_load.root
 
     def test_can_pickle_pathlib_path(self):
-        try:
-            path_1 = zipp.Path(pathlib.Path("/path/to/a/file.zip"))
-            path_1_pickle = pickle.dumps(path_1)
-            path_1_load = pickle.loads(path_1_pickle)
-            assert path_1.root == path_1_load.root
-            path_2 = zipp.Path(pathlib.Path("/path/to/a/file.zip", at="something.txt"))
-            path_2_pickle = pickle.dumps(path_2)
-            path_2_load = pickle.loads(path_2_pickle)
-            assert path_2.root == path_2_load.root
-        except TypeError as exec:
-            assert False, "TypeError: Path is not pickleable"
+        path_1 = zipp.Path(pathlib.Path("/path/to/a/file.zip"))
+        path_1_pickle = pickle.dumps(path_1)
+        path_1_load = pickle.loads(path_1_pickle)
+        assert path_1.root == path_1_load.root
+        path_2 = zipp.Path(pathlib.Path("/path/to/a/file.zip", at="something.txt"))
+        path_2_pickle = pickle.dumps(path_2)
+        path_2_load = pickle.loads(path_2_pickle)
+        assert path_2.root == path_2_load.root

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -422,8 +422,12 @@ class TestPath(unittest.TestCase):
         try:
             path_1 = zipp.Path("/path/to/a/file.zip")
             path_1_pickle = pickle.dumps(path_1)
+            path_1_load = pickle.loads(path_1_pickle)
+            assert path_1.root == path_1_load.root
             path_2 = zipp.Path("/path/to/a/file.zip", at="something.txt")
             path_2_pickle = pickle.dumps(path_2)
+            path_2_load = pickle.loads(path_2_pickle)
+            assert path_2.root == path_2_load.root
         except TypeError as exec:
             assert False, "TypeError: Path is not pickleable"
 
@@ -431,7 +435,11 @@ class TestPath(unittest.TestCase):
         try:
             path_1 = zipp.Path(pathlib.Path("/path/to/a/file.zip"))
             path_1_pickle = pickle.dumps(path_1)
+            path_1_load = pickle.loads(path_1_pickle)
+            assert path_1.root == path_1_load.root
             path_2 = zipp.Path(pathlib.Path("/path/to/a/file.zip", at="something.txt"))
             path_2_pickle = pickle.dumps(path_2)
+            path_2_load = pickle.loads(path_2_pickle)
+            assert path_2.root == path_2_load.root
         except TypeError as exec:
             assert False, "TypeError: Path is not pickleable"

--- a/test_zipp.py
+++ b/test_zipp.py
@@ -418,7 +418,7 @@ class TestPath(unittest.TestCase):
             file = cls(alpharep).joinpath('some dir').parent
             assert isinstance(file, cls)
 
-    def test_can_pickle_string_path(self):     
+    def test_can_pickle_string_path(self):
         path_1 = zipp.Path("/path/to/a/file.zip")
         path_1_pickle = pickle.dumps(path_1)
         path_1_load = pickle.loads(path_1_pickle)

--- a/zipp.py
+++ b/zipp.py
@@ -73,10 +73,11 @@ class InitializedState:
         super().__init__(*args, **kwargs)
 
     def __getstate__(self):
-        return dict(args=self.__args, kwargs=self.__kwargs)
+        return self.__args, self.__kwargs
 
     def __setstate__(self, state):
-        super().__init__(*state['args'], **state['kwargs'])
+        args, kwargs = state
+        super().__init__(*args, **kwargs)
 
 
 class CompleteDirs(InitializedState, zipfile.ZipFile):

--- a/zipp.py
+++ b/zipp.py
@@ -91,7 +91,8 @@ class PickleableClass:
         self.__dict__.update(state)
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(class={self._class}, args={self._args}, kwargs={self._kwargs})"
+        args = f"class={self._class}, args={self._args}, kwargs={self._kwargs}"
+        return f"{self.__class__.__name__}({args})"
 
     def __eq__(self, other):
         return (

--- a/zipp.py
+++ b/zipp.py
@@ -61,13 +61,15 @@ def _difference(minuend, subtrahend):
     """
     return itertools.filterfalse(set(subtrahend).__contains__, minuend)
 
-class PickleableClass():
+
+class PickleableClass:
     """
-    Utility object that wraps another un-pickleable object that, 
-    for example, might hold a file object, and saves the 
+    Utility object that wraps another un-pickleable object that,
+    for example, might hold a file object, and saves the
     initialization parameters. When pickeled, the un-pickleable
     object is discarded, and when loaded, it is rebuilt from the
     initialization params."""
+
     _class = object
 
     def __init__(self, *args, **kwargs):
@@ -92,7 +94,11 @@ class PickleableClass():
         return f"{self.__class__.__name__}(class={self._class}, args={self._args}, kwargs={self._kwargs})"
 
     def __eq__(self, other):
-        return self._class == other._class and self._args == other._args and self._kwargs == other._kwargs
+        return (
+            self._class == other._class
+            and self._args == other._args
+            and self._kwargs == other._kwargs
+        )
 
 
 class CompleteDirs(zipfile.ZipFile):
@@ -161,6 +167,7 @@ class FastLookup(CompleteDirs):
             return self.__lookup
         self.__lookup = super(FastLookup, self)._name_set()
         return self.__lookup
+
 
 class PickleableFastLookup(PickleableClass):
     _class = FastLookup

--- a/zipp.py
+++ b/zipp.py
@@ -70,7 +70,7 @@ class PickleableClass:
     object is discarded, and when loaded, it is rebuilt from the
     initialization params."""
 
-    _class = object
+    _class: type = object
 
     def __init__(self, *args, **kwargs):
         self._args = args


### PR DESCRIPTION
This addresses #81 by creating a lazy-loading `FastLookup` object if the root is a string or a `pathlib.Path` object. By doing this, when either a string or a `pathlib.Path` is used as a root for a `zipp.Path`, the path object does not hold an open file handle, and thus can be pickled.

`zipp.Path` objects that are pickleable can then be passed around multiprocessing libraries without fear of running into the dreaded `TypeError: cannot serialize '_io.BufferedReader' object` error.