### PR TITLE
Bugfix for KeyError when implied dirs are present.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v3.12.1
+=======
+
+* gh-101566: In ``CompleteDirs``, override ``ZipFile.getinfo``
+  to supply a ``ZipInfo`` for implied dirs.
+
 v3.12.0
 =======
 

--- a/tests/test_zipp.py
+++ b/tests/test_zipp.py
@@ -538,7 +538,6 @@ class TestPath(unittest.TestCase):
         """
         A zip file wrapped in a Path should extract even with implied dirs.
         """
-        self.skipTest("Fails due to python-101566")
         source_path = self.zipfile_ondisk(alpharep)
         zf = zipfile.ZipFile(source_path)
         # wrap the zipfile for its side effect

--- a/tests/test_zipp.py
+++ b/tests/test_zipp.py
@@ -532,3 +532,15 @@ class TestPath(unittest.TestCase):
         restored_1 = pickle.loads(saved_1)
         first, *rest = restored_1.iterdir()
         assert first.read_text().startswith('content of ')
+
+    @pass_alpharep
+    def test_extract_orig_with_implied_dirs(self, alpharep):
+        """
+        A zip file wrapped in a Path should extract even with implied dirs.
+        """
+        self.skipTest("Fails due to python-101566")
+        source_path = self.zipfile_ondisk(alpharep)
+        zf = zipfile.ZipFile(source_path)
+        # wrap the zipfile for its side effect
+        zipp.Path(zf)
+        zf.extractall(source_path.parent)

--- a/zipp/__init__.py
+++ b/zipp/__init__.py
@@ -113,6 +113,17 @@ class CompleteDirs(InitializedState, zipfile.ZipFile):
         dir_match = name not in names and dirname in names
         return dirname if dir_match else name
 
+    def getinfo(self, name):
+        """
+        Supplement getinfo for implied dirs.
+        """
+        try:
+            return super(CompleteDirs, self).getinfo(name)
+        except KeyError:
+            if not name.endswith('/') or name not in self._name_set():
+                raise
+            return zipfile.ZipInfo(filename=name)
+
     @classmethod
     def make(cls, source):
         """


### PR DESCRIPTION
- Add xfail test capturing missed expectation. Ref python/cpython#101566.
- Override ZipFile.getinfo to supply a ZipInfo for implied dirs. Fixes python/cpython#101566.
- Update changelog. Ref python/cpython#101566.
