### PR TITLE
Add failing test that shows that `glob()` is always `rglob()`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,11 @@ Welcome to |project| documentation!
     :undoc-members:
     :show-inheritance:
 
+.. automodule:: zipp.glob
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Indices and tables
 ==================

--- a/newsfragments/98.bugfix.rst
+++ b/newsfragments/98.bugfix.rst
@@ -1,0 +1,1 @@
+Replaced the ``fnmatch.translate`` with a fresh glob-to-regex translator for more correct matching behavior.

--- a/tests/test_zipp.py
+++ b/tests/test_zipp.py
@@ -455,15 +455,49 @@ class TestPath(unittest.TestCase):
         root = zipp.Path(alpharep)
         assert not root.match("*.txt")
 
-        assert list(root.glob("*/i.txt")) == []
-        assert list(root.rglob("*/i.txt")) == [zipp.Path(alpharep, "g/h/i.txt")]
-
         assert list(root.glob("b/c.*")) == [zipp.Path(alpharep, "b/c.txt")]
+        assert list(root.glob("b/*.txt")) == [
+            zipp.Path(alpharep, "b/c.txt"),
+            zipp.Path(alpharep, "b/f.txt"),
+        ]
 
+    @pass_alpharep
+    def test_glob_recursive(self, alpharep):
+        root = zipp.Path(alpharep)
         files = root.glob("**/*.txt")
         assert all(each.match("*.txt") for each in files)
 
         assert list(root.glob("**/*.txt")) == list(root.rglob("*.txt"))
+
+    @pass_alpharep
+    def test_glob_subdirs(self, alpharep):
+        root = zipp.Path(alpharep)
+
+        assert list(root.glob("*/i.txt")) == []
+        assert list(root.rglob("*/i.txt")) == [zipp.Path(alpharep, "g/h/i.txt")]
+
+    @pass_alpharep
+    def test_glob_does_not_overmatch_dot(self, alpharep):
+        root = zipp.Path(alpharep)
+
+        assert list(root.glob("*.xt")) == []
+
+    @pass_alpharep
+    def test_glob_single_char(self, alpharep):
+        root = zipp.Path(alpharep)
+
+        assert list(root.glob("a?txt")) == [zipp.Path(alpharep, "a.txt")]
+        assert list(root.glob("a[.]txt")) == [zipp.Path(alpharep, "a.txt")]
+        assert list(root.glob("a[?]txt")) == []
+
+    @pass_alpharep
+    def test_glob_chars(self, alpharep):
+        root = zipp.Path(alpharep)
+
+        assert list(root.glob("j/?.b[ai][nz]")) == [
+            zipp.Path(alpharep, "j/k.bin"),
+            zipp.Path(alpharep, "j/l.baz"),
+        ]
 
     def test_glob_empty(self):
         root = zipp.Path(zipfile.ZipFile(io.BytesIO(), 'w'))

--- a/tests/test_zipp.py
+++ b/tests/test_zipp.py
@@ -455,6 +455,9 @@ class TestPath(unittest.TestCase):
         root = zipp.Path(alpharep)
         assert not root.match("*.txt")
 
+        assert list(root.glob("*/i.txt")) == []
+        assert list(root.rglob("*/i.txt")) == [zipp.Path(alpharep, "g/h/i.txt")]
+
         assert list(root.glob("b/c.*")) == [zipp.Path(alpharep, "b/c.txt")]
 
         files = root.glob("**/*.txt")

--- a/zipp/__init__.py
+++ b/zipp/__init__.py
@@ -5,12 +5,18 @@ import itertools
 import contextlib
 import pathlib
 import re
-import fnmatch
 
 from .py310compat import text_encoding
 
 
 __all__ = ['Path']
+
+
+def _translate(pattern):
+    """
+    Given a glob pattern, produce a regex that matches it.
+    """
+    return pattern.replace('**', r'.*').replace('*', r'[^/]*')
 
 
 def _parents(path):
@@ -367,7 +373,7 @@ class Path:
         if not pattern:
             raise ValueError(f"Unacceptable pattern: {pattern!r}")
 
-        matches = re.compile(fnmatch.translate(pattern)).fullmatch
+        matches = re.compile(_translate(pattern)).fullmatch
         return (
             child
             for child in self._descendants()

--- a/zipp/__init__.py
+++ b/zipp/__init__.py
@@ -7,16 +7,10 @@ import pathlib
 import re
 
 from .py310compat import text_encoding
+from .glob import translate
 
 
 __all__ = ['Path']
-
-
-def _translate(pattern):
-    """
-    Given a glob pattern, produce a regex that matches it.
-    """
-    return pattern.replace('**', r'.*').replace('*', r'[^/]*')
 
 
 def _parents(path):
@@ -373,7 +367,7 @@ class Path:
         if not pattern:
             raise ValueError(f"Unacceptable pattern: {pattern!r}")
 
-        matches = re.compile(_translate(pattern)).fullmatch
+        matches = re.compile(translate(pattern)).fullmatch
         return (
             child
             for child in self._descendants()

--- a/zipp/glob.py
+++ b/zipp/glob.py
@@ -1,0 +1,40 @@
+import re
+
+
+def translate(pattern):
+    r"""
+    Given a glob pattern, produce a regex that matches it.
+
+    >>> translate('*.txt')
+    '[^/]*\\.txt'
+    >>> translate('a?txt')
+    'a.txt'
+    >>> translate('**/*')
+    '.*/[^/]*'
+    """
+    return ''.join(map(replace, separate(pattern)))
+
+
+def separate(pattern):
+    """
+    Separate out character sets to avoid translating their contents.
+
+    >>> [m.group(0) for m in separate('*.txt')]
+    ['*.txt']
+    >>> [m.group(0) for m in separate('a[?]txt')]
+    ['a', '[?]', 'txt']
+    """
+    return re.finditer(r'([^\[]+)|(?P<set>[\[].*?[\]])|([\[][^\]]*$)', pattern)
+
+
+def replace(match):
+    """
+    Perform the replacements for a match from :func:`separate`.
+    """
+
+    return match.group('set') or (
+        re.escape(match.group(0))
+        .replace('\\*\\*', r'.*')
+        .replace('\\*', r'[^/]*')
+        .replace('\\?', r'.')
+    )


### PR DESCRIPTION
Closes #98