### PR TITLE
Use PurePosixPath when matching paths in .match

### DIFF
--- a/newsfragments/92.bugfix.rst
+++ b/newsfragments/92.bugfix.rst
@@ -1,0 +1,1 @@
+In ``Path.match``, Windows path separators are no longer honored. The fact that they were was incidental and never supported.

--- a/zipp/__init__.py
+++ b/zipp/__init__.py
@@ -349,7 +349,7 @@ class Path:
         return filter(self._is_child, subs)
 
     def match(self, path_pattern):
-        return pathlib.Path(self.at).match(path_pattern)
+        return pathlib.PurePosixPath(self.at).match(path_pattern)
 
     def is_symlink(self):
         """


### PR DESCRIPTION
Closes #92
