### PR TITLE
Generalize glob functionality.

### DIFF
--- a/newsfragments/108.feature.rst
+++ b/newsfragments/108.feature.rst
@@ -1,0 +1,1 @@
+Refactored glob functionality to support a more generalized solution with support for platform-specific path separators.

--- a/zipp/__init__.py
+++ b/zipp/__init__.py
@@ -7,7 +7,7 @@ import pathlib
 import re
 
 from .py310compat import text_encoding
-from .glob import translate
+from .glob import Translator
 
 
 __all__ = ['Path']
@@ -397,7 +397,8 @@ class Path:
             raise ValueError(f"Unacceptable pattern: {pattern!r}")
 
         prefix = re.escape(self.at)
-        matches = re.compile(prefix + translate(pattern)).fullmatch
+        tr = Translator(seps='/')
+        matches = re.compile(prefix + tr.translate(pattern)).fullmatch
         return map(self._next, filter(matches, self.root.namelist()))
 
     def rglob(self, pattern):

--- a/zipp/glob.py
+++ b/zipp/glob.py
@@ -41,6 +41,7 @@ class Translator:
         >>> t.translate_core('**/*').replace('\\\\', '')
         '.*/[^/]*'
         """
+        self.restrict_rglob(pattern)
         return ''.join(map(self.replace, separate(pattern)))
 
     def replace(self, match):
@@ -53,6 +54,19 @@ class Translator:
             .replace('\\*', rf'[^{re.escape(self.seps)}]*')
             .replace('\\?', r'[^/]')
         )
+
+    def restrict_rglob(self, pattern):
+        """
+        Raise ValueError if ** appears in anything but a full path segment.
+
+        >>> Translator().translate('**foo')
+        Traceback (most recent call last):
+        ...
+        ValueError: ** must appear alone in a path segment
+        """
+        segments = re.split(rf'[{re.escape(self.seps)}]+', pattern)
+        if any('**' in segment and segment != '**' for segment in segments):
+            raise ValueError("** must appear alone in a path segment")
 
 
 def separate(pattern):

--- a/zipp/glob.py
+++ b/zipp/glob.py
@@ -2,14 +2,33 @@ import re
 
 
 def translate(pattern):
+    """
+    Given a glob pattern, produce a regex that matches it.
+    """
+    return extend(translate_core(pattern))
+
+
+def extend(pattern):
+    r"""
+    Extend regex for pattern-wide concerns.
+
+    Apply '(?s:)' to create a non-matching group that
+    matches newlines (valid on Unix).
+
+    Append '\Z' to imply fullmatch even when match is used.
+    """
+    return rf'(?s:{pattern})\Z'
+
+
+def translate_core(pattern):
     r"""
     Given a glob pattern, produce a regex that matches it.
 
-    >>> translate('*.txt')
+    >>> translate_core('*.txt')
     '[^/]*\\.txt'
-    >>> translate('a?txt')
+    >>> translate_core('a?txt')
     'a[^/]txt'
-    >>> translate('**/*')
+    >>> translate_core('**/*')
     '.*/[^/]*'
     """
     return ''.join(map(replace, separate(pattern)))

--- a/zipp/glob.py
+++ b/zipp/glob.py
@@ -1,37 +1,58 @@
+import os
 import re
 
 
-def translate(pattern):
-    """
-    Given a glob pattern, produce a regex that matches it.
-    """
-    return extend(translate_core(pattern))
+_default_seps = os.sep + str(os.altsep) * bool(os.altsep)
 
 
-def extend(pattern):
-    r"""
-    Extend regex for pattern-wide concerns.
+class Translator:
+    seps: str
 
-    Apply '(?s:)' to create a non-matching group that
-    matches newlines (valid on Unix).
+    def __init__(self, seps: str = _default_seps):
+        assert seps in ('/', '\\', '\\/')
+        self.seps = _default_seps
 
-    Append '\Z' to imply fullmatch even when match is used.
-    """
-    return rf'(?s:{pattern})\Z'
+    def translate(self, pattern):
+        """
+        Given a glob pattern, produce a regex that matches it.
+        """
+        return self.extend(self.translate_core(pattern))
 
+    def extend(self, pattern):
+        r"""
+        Extend regex for pattern-wide concerns.
 
-def translate_core(pattern):
-    r"""
-    Given a glob pattern, produce a regex that matches it.
+        Apply '(?s:)' to create a non-matching group that
+        matches newlines (valid on Unix).
 
-    >>> translate_core('*.txt')
-    '[^/]*\\.txt'
-    >>> translate_core('a?txt')
-    'a[^/]txt'
-    >>> translate_core('**/*')
-    '.*/[^/]*'
-    """
-    return ''.join(map(replace, separate(pattern)))
+        Append '\Z' to imply fullmatch even when match is used.
+        """
+        return rf'(?s:{pattern})\Z'
+
+    def translate_core(self, pattern):
+        r"""
+        Given a glob pattern, produce a regex that matches it.
+
+        >>> t = Translator()
+        >>> t.translate_core('*.txt').replace('\\\\', '')
+        '[^/]*\\.txt'
+        >>> t.translate_core('a?txt')
+        'a[^/]txt'
+        >>> t.translate_core('**/*').replace('\\\\', '')
+        '.*/[^/]*'
+        """
+        return ''.join(map(self.replace, separate(pattern)))
+
+    def replace(self, match):
+        """
+        Perform the replacements for a match from :func:`separate`.
+        """
+        return match.group('set') or (
+            re.escape(match.group(0))
+            .replace('\\*\\*', r'.*')
+            .replace('\\*', rf'[^{re.escape(self.seps)}]*')
+            .replace('\\?', r'[^/]')
+        )
 
 
 def separate(pattern):
@@ -44,16 +65,3 @@ def separate(pattern):
     ['a', '[?]', 'txt']
     """
     return re.finditer(r'([^\[]+)|(?P<set>[\[].*?[\]])|([\[][^\]]*$)', pattern)
-
-
-def replace(match):
-    """
-    Perform the replacements for a match from :func:`separate`.
-    """
-
-    return match.group('set') or (
-        re.escape(match.group(0))
-        .replace('\\*\\*', r'.*')
-        .replace('\\*', r'[^/]*')
-        .replace('\\?', r'[^/]')
-    )

--- a/zipp/glob.py
+++ b/zipp/glob.py
@@ -6,10 +6,22 @@ _default_seps = os.sep + str(os.altsep) * bool(os.altsep)
 
 
 class Translator:
+    """
+    >>> Translator('xyz')
+    Traceback (most recent call last):
+    ...
+    AssertionError: Invalid separators
+
+    >>> Translator('')
+    Traceback (most recent call last):
+    ...
+    AssertionError: Invalid separators
+    """
+
     seps: str
 
     def __init__(self, seps: str = _default_seps):
-        assert seps in ('/', '\\', '\\/')
+        assert seps and set(seps) <= set(_default_seps), "Invalid separators"
         self.seps = seps
 
     def translate(self, pattern):

--- a/zipp/glob.py
+++ b/zipp/glob.py
@@ -10,7 +10,7 @@ class Translator:
 
     def __init__(self, seps: str = _default_seps):
         assert seps in ('/', '\\', '\\/')
-        self.seps = _default_seps
+        self.seps = seps
 
     def translate(self, pattern):
         """


### PR DESCRIPTION
Inspired by work in python/cpython#106703.

Achieves:

- [x] Adds support for newlines and fullmatch in the generated pattern.
- [x] Adds support for arbitrary path separators, defaulting to platform separators.
- [x] Fails when `**` appears as anything but a full path segment.
- [x] Requires at least one char for `*` in a full path segment.