### PR TITLE
Remove unexpected character \ufeff

### DIFF
--- a/zipp/__init__.py
+++ b/zipp/__init__.py
@@ -281,7 +281,7 @@ class Path:
     >>> str(path.parent)
     'mem'
 
-    If the zipfile has no filename, such ﻿attributes are not
+    If the zipfile has no filename, such attributes are not
     valid and accessing them will raise an Exception.
 
     >>> zf.filename = None


### PR DESCRIPTION
The comment line somehow had unexpected unicode character added by ff0b75ec6fb8def49cebcb58523ec4ff3d9cca56. Found via https://phabricator.services.mozilla.com/D220347#C8303474NL332