### PR TITLE
Don't rely on `Path.iterdir()` output order in tests

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,14 @@
+v3.21.0
+=======
+
+Features
+--------
+
+- Improve performances of :meth:`zipfile.Path.open` for non-reading modes. (1a1928d)
+- Rely on cached_property to cache values on the instance.
+- Rely on save_method_args to save method args.
+
+
 v3.20.2
 =======
 

--- a/newsfragments/+275f3051.feature.rst
+++ b/newsfragments/+275f3051.feature.rst
@@ -1,1 +1,0 @@
-Rely on save_method_args to save method args.

--- a/newsfragments/+f9a115e5.feature.rst
+++ b/newsfragments/+f9a115e5.feature.rst
@@ -1,1 +1,0 @@
-Rely on cached_property to cache values on the instance.

--- a/newsfragments/1a1928d.feature.rst
+++ b/newsfragments/1a1928d.feature.rst
@@ -1,1 +1,0 @@
-Improve performances of :meth:`zipfile.Path.open` for non-reading modes.

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -96,11 +96,11 @@ class TestPath(unittest.TestCase):
     def test_iterdir_and_types(self, alpharep):
         root = zipfile.Path(alpharep)
         assert root.is_dir()
-        a, n, b, g, j = root.iterdir()
+        a, b, g, j, n = sorted(root.iterdir(), key=lambda p: p.name)
         assert a.is_file()
         assert b.is_dir()
         assert g.is_dir()
-        c, f, d = b.iterdir()
+        c, d, f = sorted(b.iterdir(), key=lambda p: p.name)
         assert c.is_file() and f.is_file()
         (e,) = d.iterdir()
         assert e.is_file()
@@ -131,7 +131,7 @@ class TestPath(unittest.TestCase):
     @pass_alpharep
     def test_open(self, alpharep):
         root = zipfile.Path(alpharep)
-        a, n, b, g, j = root.iterdir()
+        a, b, g, j, n = sorted(root.iterdir(), key=lambda p: p.name)
         with a.open(encoding="utf-8") as strm:
             data = strm.read()
         self.assertEqual(data, "content of a")
@@ -235,7 +235,7 @@ class TestPath(unittest.TestCase):
     @pass_alpharep
     def test_read(self, alpharep):
         root = zipfile.Path(alpharep)
-        a, n, b, g, j = root.iterdir()
+        a, b, g, j, n = sorted(root.iterdir(), key=lambda p: p.name)
         assert a.read_text(encoding="utf-8") == "content of a"
         # Also check positional encoding arg (gh-101144).
         assert a.read_text("utf-8") == "content of a"
@@ -301,7 +301,7 @@ class TestPath(unittest.TestCase):
         reflect that change.
         """
         root = zipfile.Path(alpharep)
-        a, n, b, g, j = root.iterdir()
+        a, b, g, j, n = sorted(root.iterdir(), key=lambda p: p.name)
         alpharep.writestr('foo.txt', 'foo')
         alpharep.writestr('bar/baz.txt', 'baz')
         assert any(child.name == 'foo.txt' for child in root.iterdir())
@@ -617,7 +617,7 @@ class TestPath(unittest.TestCase):
         zf.writestr("V: NMS.flac", b"fLaC...")
         zf.filename = ''
         root = zipfile.Path(zf)
-        contents = root.iterdir()
+        contents = iter(sorted(root.iterdir(), key=lambda p: len(p.name)))
         assert next(contents).name == 'path?'
         assert next(contents).name == 'V: NMS.flac'
         assert root.joinpath('V: NMS.flac').read_bytes() == b"fLaC..."


### PR DESCRIPTION
Adjust tests for `zipp.Path.iterdir()` to sort the resulting paths by name. Previously the tests depended on how `CompleteDirs` inserts synthetic directory entries, which is very much an implementation detail!

Resolves #130