### PR TITLE
Add dependency on `pathlib-abc`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ nitpick_ignore: list[tuple[str, str]] = []
 extensions += ['sphinx.ext.intersphinx']
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
+    'pathlib_abc': ('https://pathlib-abc.readthedocs.io/en/latest/', None),
 }
 
 # Preserve authored syntax for defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 requires-python = ">=3.9"
 license = "MIT"
 dependencies = [
+	"pathlib-abc"
 ]
 dynamic = ["version"]
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -183,6 +183,10 @@ class TestPath(unittest.TestCase):
         not getattr(sys.flags, 'warn_default_encoding', 0),
         "Requires warn_default_encoding",
     )
+    @unittest.skipIf(
+        sys.implementation.name == 'pypy' and sys.pypy_version_info < (7, 3, 19),
+        "Older PyPy versions set the wrong stacklevel in text_encoding()"
+    )
     @pass_alpharep
     def test_encoding_warnings(self, alpharep):
         """EncodingWarning must blame the read_text and open calls."""

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -185,7 +185,7 @@ class TestPath(unittest.TestCase):
     )
     @unittest.skipIf(
         sys.implementation.name == 'pypy' and sys.pypy_version_info < (7, 3, 19),
-        "Older PyPy versions set the wrong stacklevel in text_encoding()"
+        "Older PyPy versions set the wrong stacklevel in text_encoding()",
     )
     @pass_alpharep
     def test_encoding_warnings(self, alpharep):


### PR DESCRIPTION
Make `zipp.Path` subclass `pathlib_abc.ReadablePath`. This allows us to remove implementations of `read_text()`, `read_bytes()`, `glob()`, `joinpath()` and `__truediv__()`, and to simplify implementations of a couple of few more methods.

Maintain a tree of `PathInfo` objects representing the hierarchy of zip file members. We traverse the tree whenever we need to resolve a path to a `ZipInfo` object. This effectively hides the `.zip`-specific quirk that directories are recorded with a trailing slash in their filenames.

Adjust `__str__()` so that it doesn't raise for unnamed zip files. Instead it returns a string beginning with `:fileobj:`. The prefix is made available as a new `anchor` attribute.

Add the following methods/attributes, which are required by `ReadablePath`:

- `info`
- `parser`
- `__open_rb__()`
- `readlink()`
- `with_segments()`

Disable the following `ReadablePath` methods/attributes that we don't (yet) test in zipp:

- `anchor`
- `parts`
- `parents`
- `__rtruediv__()`
- `with_name()`
- `with_stem()`
- `with_suffix()`
- `full_match()`
- `walk()`
- `copy()`
- `copy_into()`
