### PR TITLE
Prevent circular dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm[toml]>=3.4.1"]
+requires = [
+	"setuptools>=61.2", 
+	"setuptools_scm[toml]>=3.4.1",
+	# Limit the max version of setuptools_scm on older Python to prevent circular
+	# dependencies. See: https://github.com/jaraco/zipp/issues/137
+	"setuptools_scm[toml]<8.3.0; python_version < '3.10'",
+]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This limits the version of `setuptools_scm` that we can use for builds on older Python in order to prevent a circular dependency situation.

Fixes #137