### PR TITLE
Fix circular dependency for 3.20 series

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm[toml]>=3.4.1"]
+requires = [
+	"setuptools>=61.2", 
+	"setuptools_scm[toml]>=3.4.1",
+	# Limit the max version of setuptools_scm on older Python to prevent circular
+	# dependencies. See: https://github.com/jaraco/zipp/issues/137
+	"setuptools_scm[toml]<8.3.0; python_version < '3.10'",
+]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This fixes #137 for the 3.20 series (the last versions to support Python 3.8).

This is the same as #138 , but it'll need re-targeting to a branch based on v3.20.2.