### PR TITLE
Use Windows path rules to parse ``ZipFile.filename`` on Windows

### DIFF
--- a/newsfragments/133.bugfix.rst
+++ b/newsfragments/133.bugfix.rst
@@ -1,0 +1,1 @@
+Use Windows path rules to parse ``ZipFile.filename`` on Windows

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -356,6 +356,7 @@ class TestPath(unittest.TestCase):
         """
         The name of the root should be the name of the zipfile
         """
+        alpharep = self.zipfile_ondisk(alpharep)
         root = zipfile.Path(alpharep)
         assert root.name == 'alpharep.zip' == root.filename.name
 
@@ -412,6 +413,7 @@ class TestPath(unittest.TestCase):
         """
         The final path component, without its suffix
         """
+        alpharep = self.zipfile_ondisk(alpharep)
         root = zipfile.Path(alpharep)
         assert root.stem == 'alpharep' == root.filename.stem
 

--- a/zipp/__init__.py
+++ b/zipp/__init__.py
@@ -353,7 +353,10 @@ class Path:
         return io.TextIOWrapper(stream, encoding, *args, **kwargs)
 
     def _base(self):
-        return pathlib.PurePosixPath(self.at or self.root.filename)
+        if self.at:
+            return pathlib.PurePosixPath(self.at)
+        else:
+            return pathlib.PurePath(self.root.filename)
 
     @property
     def name(self):


### PR DESCRIPTION
Fixes #133