### PR TITLE
Backport use of `\z` in glob.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
 	# leading `*/` for pytest-dev/pytest-cov#456
 	*/.tox/*
+	zipp/compat/py313.py
 disable_warnings =
 	couldnt-parse
 

--- a/newsfragments/145.feature.rst
+++ b/newsfragments/145.feature.rst
@@ -1,0 +1,1 @@
+Add a compatibility shim for Python 3.13 and earlier.

--- a/zipp/compat/py313.py
+++ b/zipp/compat/py313.py
@@ -1,0 +1,34 @@
+import functools
+import sys
+
+
+# from jaraco.functools 4.1
+def identity(x):
+    return x
+
+
+# from jaraco.functools 4.1
+def apply(transform):
+    def wrap(func):
+        return functools.wraps(func)(compose(transform, func))
+
+    return wrap
+
+
+# from jaraco.functools 4.1
+def compose(*funcs):
+    def compose_two(f1, f2):
+        return lambda *args, **kwargs: f1(f2(*args, **kwargs))
+
+    return functools.reduce(compose_two, funcs)
+
+
+def replace(pattern):
+    r"""
+    >>> replace(r'foo\z')
+    'foo\\Z'
+    """
+    return pattern[:-2] + pattern[-2:].replace(r'\z', r'\Z')
+
+
+legacy_end_marker = apply(replace) if sys.version_info < (3, 14) else identity

--- a/zipp/glob.py
+++ b/zipp/glob.py
@@ -36,9 +36,9 @@ class Translator:
         Apply '(?s:)' to create a non-matching group that
         matches newlines (valid on Unix).
 
-        Append '\Z' to imply fullmatch even when match is used.
+        Append '\z' to imply fullmatch even when match is used.
         """
-        return rf'(?s:{pattern})\Z'
+        return rf'(?s:{pattern})\z'
 
     def match_dirs(self, pattern):
         """

--- a/zipp/glob.py
+++ b/zipp/glob.py
@@ -1,6 +1,8 @@
 import os
 import re
 
+from .compat.py313 import legacy_end_marker
+
 _default_seps = os.sep + str(os.altsep) * bool(os.altsep)
 
 
@@ -29,6 +31,7 @@ class Translator:
         """
         return self.extend(self.match_dirs(self.translate_core(pattern)))
 
+    @legacy_end_marker
     def extend(self, pattern):
         r"""
         Extend regex for pattern-wide concerns.


### PR DESCRIPTION
- **gh-133306: Use \z instead of \Z in regular expressions in the stdlib (GH-133337)**
- **Add a compatibility shim for Python 3.13 and earlier.**
