### PR TITLE
Stop working around bug in PyPy < 7.3.18

### DIFF
--- a/newsfragments/149.removal.rst
+++ b/newsfragments/149.removal.rst
@@ -1,0 +1,1 @@
+Drop workaround for stacklevel bug on older PyPy releases.

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -184,7 +184,7 @@ class TestPath(unittest.TestCase):
         "Requires warn_default_encoding",
     )
     @unittest.skipIf(
-        sys.implementation.name == 'pypy' and sys.pypy_version_info < (7, 3, 19),
+        sys.implementation.name == 'pypy' and sys.pypy_version_info < (7, 3, 18),
         "Older PyPy versions set the wrong stacklevel in text_encoding()",
     )
     @pass_alpharep

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -183,6 +183,10 @@ class TestPath(unittest.TestCase):
         not getattr(sys.flags, 'warn_default_encoding', 0),
         "Requires warn_default_encoding",
     )
+    @unittest.skipIf(
+        sys.implementation.name == 'pypy' and sys.pypy_version_info < (7, 3, 19),
+        "Older PyPy versions set the wrong stacklevel in text_encoding()",
+    )
     @pass_alpharep
     def test_encoding_warnings(self, alpharep):
         """EncodingWarning must blame the read_text and open calls."""


### PR DESCRIPTION
PyPy used to set the stack level incorrectly when emitting warnings from `io.text_encoding()`, but this bug is too minor and too obscure to bother working around. Plus it's fixed in recent PyPy.

See https://github.com/pypy/pypy/commit/6ca2f486ed1587a4d0fa693ce011e57c78e7d6c8